### PR TITLE
Add `cargo-tree` to build set

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,7 @@ jobs:
           - cargo-tarpaulin
           - cargo-cache
           - cargo-web
+          - cargo-tree
 
           - cross
           - sccache


### PR DESCRIPTION
I'm using `cargo tree ...` to list the included/used dependency set for a given build (see the "Info" step of the "MinSRV" or any "Build ..." job @ <https://github.com/rivy/rs.coreutils/runs/572806067?check_suite_focus=true>). It helps track down build errors which creep in over time solely due to dependency changes (ie, non-semantic version updates).

I'd appreciate `cargo-tree` being available to avoid the build cost.

Thanks.
