### PR TITLE
Add cargo-fuzz to the build.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,7 @@ jobs:
           - cargo-web
           - cargo-tree
           - cargo-binutils
+          - cargo-fuzz
 
           - cross
           - sccache


### PR DESCRIPTION
This adds [`cargo-fuzz`](https://github.com/rust-fuzz/cargo-fuzz) to the tool cache.