### PR TITLE
Add cargo-deadlinks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,7 @@ jobs:
           - cargo-binutils
           - cargo-fuzz
           - cargo-deb
+          - cargo-deadlinks
 
           - cross
           - sccache


### PR DESCRIPTION
See https://github.com/deadlinks/cargo-deadlinks for more information.

We (https://github.com/rust-random/getrandom) want to use this in our CI.

Signed-off-by: Joe Richey <joerichey@google.com>